### PR TITLE
SVN plugin fixed

### DIFF
--- a/ic-depress-scm-svn/src/org/impressivecode/depress/scm/svn/SVNExtensionParser.java
+++ b/ic-depress-scm-svn/src/org/impressivecode/depress/scm/svn/SVNExtensionParser.java
@@ -91,14 +91,15 @@ public class SVNExtensionParser {
             if (entry.getPaths() == null) {
                 continue;
             }
-            SCMDataType base = scmBase(entry);
-            for (Path path : entry.getPaths().getPath()) {
-                if (include(path, parserOptions)) {
-                    scmEntries.add(scm((SCMDataType) base.clone(), path));
-                }
-            }
             if (!entry.getLogentry().isEmpty()) {
                 parseLogEntries(entry.getLogentry(), scmEntries, parserOptions);
+            }else{
+            	SCMDataType base = scmBase(entry);
+	            for (Path path : entry.getPaths().getPath()) {
+	                if (include(path, parserOptions)) {
+	                    scmEntries.add(scm((SCMDataType) base.clone(), path));
+	                }
+	            }
             }
         }
     }


### PR DESCRIPTION
Before the fix the SCM/SVN plugin read merge-logentry and its internal
logentries as different commits; now the merge commit is omitted and
only its internal logentries are treated as commits