### PR TITLE
SVN plugin fixed

### DIFF
--- a/src/org/impressivecode/depress/scm/svn/SVNOfflineLogParser.java
+++ b/src/org/impressivecode/depress/scm/svn/SVNOfflineLogParser.java
@@ -93,14 +93,15 @@ public class SVNOfflineLogParser {
             if (entry.getPaths() == null) {
                 continue;
             }
-            SCMDataType base = scmBase(entry);
-            for (Path path : entry.getPaths().getPath()) {
-                if (include(path, parserOptions)) {
-                    scmEntries.add(scm((SCMDataType) base.clone(), path));
-                }
-            }
             if (!entry.getLogentry().isEmpty()) {
                 parseLogEntries(entry.getLogentry(), scmEntries, parserOptions);
+            }else{
+            	SCMDataType base = scmBase(entry);
+	            for (Path path : entry.getPaths().getPath()) {
+	                if (include(path, parserOptions)) {
+	                    scmEntries.add(scm((SCMDataType) base.clone(), path));
+	                }
+	            }
             }
         }
     }


### PR DESCRIPTION
Before the fix the SCM/SVN plugin read merge-logentry and its internal
logentries as different commits; now the merge commit is omitted and
only its internal logentries are treated as commits